### PR TITLE
Make elevators less bloodthirsty (no more ending up in walls)

### DIFF
--- a/src/main/java/openblocks/common/ElevatorActionHandler.java
+++ b/src/main/java/openblocks/common/ElevatorActionHandler.java
@@ -103,7 +103,26 @@ public class ElevatorActionHandler {
 			if (doTeleport) {
 				if (result.rotation != PlayerRotation.NONE) player.rotationYaw = getYaw(result.rotation);
 				if (Config.elevatorCenter) player.setPositionAndUpdate(x + 0.5, result.level + 1.1, z + 0.5);
-				else player.setPositionAndUpdate(player.posX, result.level + 1.1, player.posZ);
+				else {
+					int minX = (int)Math.floor(player.posX - player.width/2);
+					int minZ = (int)Math.floor(player.posZ - player.width/2);
+					int maxX = (int)Math.floor(player.posX + player.width/2);
+					int maxZ = (int)Math.floor(player.posZ + player.width/2);
+
+					boolean canSafelyTeleport = true;
+					for(int i = minX; i <= maxX; i++) {
+						for(int j = minZ; j <= maxZ; j++) {
+							if(!world.isAirBlock(i, result.level +1, j) || !world.isAirBlock(j, result.level+2, j))							{
+								canSafelyTeleport = false;
+								break;
+							}
+						}
+					}
+					if(canSafelyTeleport)
+						player.setPositionAndUpdate(player.posX, result.level + 1.1, player.posZ);
+					else
+						player.setPositionAndUpdate(x + 0.5, result.level + 1.1, z + 0.5);
+				}
 				world.playSoundAtEntity(player, "openblocks:elevator.activate", 1, 1);
 			}
 		}


### PR DESCRIPTION
This changes elevators so that if the player was to end up (partially) inside a wall after using the elevator, they instead end up on center. If there's no wall at target location, it should behave like before. Could potentially be improved to only move the player away from the wall on one axis when possible.