### PR TITLE
Nerf Last Stand so it's random when it applies

### DIFF
--- a/src/main/java/openblocks/enchantments/LastStandEnchantmentsHandler.java
+++ b/src/main/java/openblocks/enchantments/LastStandEnchantmentsHandler.java
@@ -73,10 +73,14 @@ public class LastStandEnchantmentsHandler {
 						}).floatValue();
 
 				if (xpAvailable >= xpRequired) {
-					e.player.setHealth(1f);
-					EnchantmentUtils.addPlayerXP(e.player, -(int)xpRequired);
-					e.amount = 0;
-					e.setCanceled(true);
+					int rn = random.nextInt(101);
+					rn = rn+enchantmentLevels;
+					if (rn >=25) {
+						e.player.setHealth(1f);
+						EnchantmentUtils.addPlayerXP(e.player, -(int)xpRequired);
+						e.amount = 0;
+						e.setCanceled(true);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
RN(should be 1-100)+enchantmentLevels (this should be 1-12 if you overenchant all 4 pieces, if you can't/don't overenchant, 1-8) = 2/9/13 to 102/109/113.
If RN >= 25, succeed, otherwise fail and you die.

I don't know how many times people use LS in a row, so I'm not sure what pass/fail rate it should be, but this can be easily changed by changing the 25. Higher =Less chance of succeeding.

I also can't build it myself, so there's a possibility building might fail.

See https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/6672