### PR TITLE
Fix Glider behaviour in rain.

### DIFF
--- a/src/main/java/openblocks/common/entity/EntityHangGlider.java
+++ b/src/main/java/openblocks/common/entity/EntityHangGlider.java
@@ -230,7 +230,7 @@ public class EntityHangGlider extends Entity implements IEntityAdditionalSpawnDa
 
 		if (player.dimension != 0)
 			noise = 0;
-		else if (worldObj.isRaining() && !strong)
+		else if (worldObj.isRaining() && player.isWet() && !strong)
 			noise = (biomeRain > 0? -0.5 : 0);
 		return noise;
 	}


### PR DESCRIPTION
Glider drop-off no longer applies if you're not actually in the rain.

Haven't tested this since OB throws build errors after a default import. But I don't see why it wouldn't work.