### PR TITLE
Fix Scaffolding step sound

### DIFF
--- a/src/main/java/openblocks/common/block/BlockScaffolding.java
+++ b/src/main/java/openblocks/common/block/BlockScaffolding.java
@@ -19,6 +19,7 @@ public class BlockScaffolding extends OpenBlock {
         super(Material.cloth);
         setTickRandomly(true);
         setHardness(0.1F);
+        setStepSound(Block.soundTypeWood);
     }
 
     @Override


### PR DESCRIPTION
Make Scaffolding use wood sounds instead of the default sounds.