### PR TITLE
Improve item config toggles

### DIFF
--- a/src/main/java/openblocks/NEIOpenBlocksConfig.java
+++ b/src/main/java/openblocks/NEIOpenBlocksConfig.java
@@ -5,6 +5,8 @@ import java.lang.reflect.Method;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
+import openblocks.common.item.MetasGeneric;
+import openblocks.common.item.MetasGenericUnstackable;
 import openmods.Log;
 import codechicken.nei.api.IConfigureNEI;
 
@@ -25,6 +27,14 @@ public class NEIOpenBlocksConfig implements IConfigureNEI {
 
         if (OpenBlocks.Items.heightMap != null) {
             API$hideItem(new ItemStack(OpenBlocks.Items.heightMap, 1, OreDictionary.WILDCARD_VALUE));
+        }
+
+        if (!MetasGeneric.subItemEnabled()) {
+            API$hideItem(new ItemStack(OpenBlocks.Items.generic, 1, OreDictionary.WILDCARD_VALUE));
+        }
+
+        if (!MetasGenericUnstackable.subItemEnabled()) {
+            API$hideItem(new ItemStack(OpenBlocks.Items.genericUnstackable, 1, OreDictionary.WILDCARD_VALUE));
         }
 
         Log.info("OpenBlocks NEI Integration loaded successfully");

--- a/src/main/java/openblocks/common/item/MetasGeneric.java
+++ b/src/main/java/openblocks/common/item/MetasGeneric.java
@@ -25,6 +25,11 @@ public enum MetasGeneric {
                     new ShapedOreRecipe(result, " sl", "sll", "lll", 's', "stickWood", 'l', Items.leather),
                     new ShapedOreRecipe(result, "ls ", "lls", "lll", 's', "stickWood", 'l', Items.leather));
         }
+
+        @Override
+        public boolean isEnabled() {
+            return OpenBlocks.Items.hangGlider != null;
+        }
     },
     beam {
 
@@ -56,6 +61,11 @@ public enum MetasGeneric {
                             'y',
                             "dyeYellow"));
         }
+
+        @Override
+        public boolean isEnabled() {
+            return OpenBlocks.Items.craneBackpack != null;
+        }
     },
     craneEngine {
 
@@ -75,6 +85,11 @@ public enum MetasGeneric {
                             "stickWood",
                             'r',
                             "dustRedstone"));
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return OpenBlocks.Items.craneBackpack != null;
         }
     },
     craneMagnet {
@@ -108,6 +123,12 @@ public enum MetasGeneric {
                             "dyeBlack",
                             'y',
                             "dyeYellow"));
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return OpenBlocks.Items.craneBackpack != null
+                    || (Loader.isModLoaded(openmods.Mods.OPENPERIPHERALCORE) && Config.enableCraneTurtles);
         }
     },
     miracleMagnet {
@@ -156,6 +177,11 @@ public enum MetasGeneric {
                     "line",
                     new ShapedOreRecipe(result, "sss", "bbb", "sss", 's', Items.string, 'b', "slimeball"));
         }
+
+        @Override
+        public boolean isEnabled() {
+            return OpenBlocks.Items.craneBackpack != null;
+        }
     },
     mapController {
 
@@ -166,6 +192,11 @@ public enum MetasGeneric {
                     "map_controller",
                     new ShapedOreRecipe(result, " r ", "rgr", " r ", 'r', "dustRedstone", 'g', "ingotGold"));
         }
+
+        @Override
+        public boolean isEnabled() {
+            return OpenBlocks.Items.emptyMap != null;
+        }
     },
     mapMemory {
 
@@ -175,6 +206,11 @@ public enum MetasGeneric {
             return new MetaGeneric(
                     "map_memory",
                     new ShapedOreRecipe(result, "rg", "rg", "rg", 'g', "nuggetGold", 'r', "dustRedstone"));
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return OpenBlocks.Items.emptyMap != null;
         }
     },
     /**
@@ -211,6 +247,11 @@ public enum MetasGeneric {
                             'r',
                             "dustRedstone"));
         }
+
+        @Override
+        public boolean isEnabled() {
+            return OpenBlocks.Items.cartographer != null;
+        }
     },
     unpreparedStencil {
 
@@ -220,6 +261,11 @@ public enum MetasGeneric {
             return new MetaGeneric(
                     "unprepared_stencil",
                     new ShapedOreRecipe(result, " p ", "pip", " p ", 'p', Items.paper, 'i', "ingotIron"));
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return OpenBlocks.Blocks.drawingTable != null;
         }
     },
     sketchingPencil {
@@ -238,6 +284,11 @@ public enum MetasGeneric {
                             new ItemStack(Items.coal, 1, OreDictionary.WILDCARD_VALUE),
                             's',
                             "stickWood"));
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return OpenBlocks.Blocks.drawingTable != null;
         }
     };
 
@@ -274,5 +325,12 @@ public enum MetasGeneric {
                             MetasGeneric.unpreparedStencil.newItemStack()));
         }
 
+    }
+
+    public static boolean subItemEnabled() {
+        for (MetasGeneric m : values()) if (m.isEnabled()) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/openblocks/common/item/MetasGenericUnstackable.java
+++ b/src/main/java/openblocks/common/item/MetasGenericUnstackable.java
@@ -19,6 +19,11 @@ public enum MetasGenericUnstackable {
             final ItemStack whiteWool = ColorMeta.WHITE.createStack(Blocks.wool, 1);
             return new MetaPointer("pointer", new ShapedOreRecipe(result, "w  ", "ww ", "w  ", 'w', whiteWool));
         }
+
+        @Override
+        public boolean isEnabled() {
+            return OpenBlocks.Blocks.cannon != null;
+        }
     };
 
     public ItemStack newItemStack(int size) {
@@ -42,5 +47,12 @@ public enum MetasGenericUnstackable {
     public static void registerItems() {
         for (MetasGenericUnstackable m : values())
             if (m.isEnabled()) Items.genericUnstackable.registerItem(m.ordinal(), m.createMetaItem());
+    }
+
+    public static boolean subItemEnabled() {
+        for (MetasGenericUnstackable m : values()) if (m.isEnabled()) {
+            return true;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Meta-items will not have specific sub-items registered if they are unneeded. For example, if the hang-glider is disabled the hang-glider wings item will no longer have a recipe or be registered. If all sub-items in a meta-item are disabled the unused meta zero item will be hidden from NEI as well.