### PR TITLE
Make BlockGrave use the same logic as TileEntityGrave to determine player name

### DIFF
--- a/src/main/java/openblocks/common/block/BlockGrave.java
+++ b/src/main/java/openblocks/common/block/BlockGrave.java
@@ -91,7 +91,7 @@ public class BlockGrave extends OpenBlock {
 
         if (tile instanceof TileEntityGrave) {
             TileEntityGrave graveStone = (TileEntityGrave) tile;
-            if (Objects.equals(graveStone.getUsername(), player.getDisplayName())) return 2.0F;
+            if (Objects.equals(graveStone.getUsername(), player.getGameProfile().getName())) return 2.0F;
         }
 
         return super.getPlayerRelativeBlockHardness(player, world, x, y, z);


### PR DESCRIPTION
This PR makes `BlockGrave#getPlayerRelativeBlockHardness` use `EntityPlayer#getGameProfile#getName` instead of `EntityPlayer#getDisplayName` to determine the player's name, and compare it with that stored in the gravestone tile entity.

This fixes incompatibilities with mods that change the player's `displayname`, i.e. FTB Utilities with its "nicknames" function. The `displayname` of a player is much more susceptible to change than their profile's username.