### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/openblocks/lang/en_US.lang
+++ b/src/main/resources/assets/openblocks/lang/en_US.lang
@@ -310,6 +310,8 @@ item.openblocks.hangglider.name=Hang Glider
 item.openblocks.hangglider.invalid_dimension=It seems the glider doesn't work, perhaps the atmosphere is too thin?
 item.openblocks.hangglider.description=The hang glider is self explanatory. Hold it in your hand and click to place it on your back. Now jump!\nTo increase your speed you can press shift while gliding, but watch out, you'll lose altitude faster!\n\nYour hang glider now also includes an acoustic variometer indicating vertical air movement. Press V to activate it and stay up forever (or until the sun goes down)!
 
+item.openblocks.generic.name=Item
+
 item.openblocks.gliderwing.name=Glider Wing
 
 item.openblocks.sleepingbag.name=Sleeping Bag
@@ -340,6 +342,7 @@ item.openblocks.wrench.name=Big Metal Bar
 item.openblocks.wrench.description=This is extremely sophisticated tool used to perform transformations of objects with octahedral symmetry.\n\n\nOr just big, dumb piece of metal you can use to rotate cubes and stuff.\n\nSo yeah, it's yet another wrench. I'm just trying to be original here, ok?
 
 item.openblocks.stencil.name=Stencil
+item.openblocks.imaginary.name=Magic Crayon/Pencil
 item.openblocks.crayon.name=Magic Crayon
 item.openblocks.pencil.name=Magic Pencil
 item.openblocks.glasses.pencil.name=Pencil Glasses
@@ -352,6 +355,7 @@ item.openblocks.beam.name=Beam
 item.openblocks.line.name=Line
 item.openblocks.miracle_magnet.name=§5Miracle Magnet§r
 item.openblocks.info_book.name=World Domination with OpenBlocks
+item.openblocks.filledbucket.name=XP Bucket
 item.openblocks.xpbucket.name=XP Bucket
 item.openblocks.height_map.name=Height Map
 item.openblocks.empty_map.name=Empty Map
@@ -362,6 +366,7 @@ item.openblocks.assistant_base.name=Assistant's base
 item.openblocks.sketching_pencil.name=Sketching Pencil
 item.openblocks.tasty_clay.name=Tasty Clay
 item.openblocks.golden_eye.name=Golden eye
+item.openblocks.genericUnstackable.name=Pointer
 item.openblocks.pointer.name=Pointer
 item.openblocks.tuned_crystal.name=Tuned Crystal
 item.openblocks.pedometer.name=Pedometer


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.