### PR TITLE
Fixed glider requiring two clicks after scrolling away

### DIFF
--- a/src/main/java/openblocks/common/entity/EntityHangGlider.java
+++ b/src/main/java/openblocks/common/entity/EntityHangGlider.java
@@ -47,7 +47,7 @@ public class EntityHangGlider extends Entity implements IEntityAdditionalSpawnDa
 
     private static final int PROPERTY_DEPLOYED = 17;
 
-    private static HashMap<EntityPlayer, EntityHangGlider> gliderMap = new HashMap<EntityPlayer, EntityHangGlider>();
+    private static Map<EntityPlayer, EntityHangGlider> gliderMap = new HashMap<>();
 
     private IVarioController varioControl = IVarioController.NULL;
 

--- a/src/main/java/openblocks/common/entity/EntityHangGlider.java
+++ b/src/main/java/openblocks/common/entity/EntityHangGlider.java
@@ -1,6 +1,7 @@
 package openblocks.common.entity;
 
 import java.util.Calendar;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
@@ -11,8 +12,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import net.minecraft.world.gen.NoiseGeneratorPerlin;
-
-import com.google.common.collect.MapMaker;
 
 import cpw.mods.fml.common.registry.IEntityAdditionalSpawnData;
 import cpw.mods.fml.relauncher.Side;
@@ -48,7 +47,7 @@ public class EntityHangGlider extends Entity implements IEntityAdditionalSpawnDa
 
     private static final int PROPERTY_DEPLOYED = 17;
 
-    private static Map<EntityPlayer, EntityHangGlider> gliderMap = new MapMaker().weakKeys().weakValues().makeMap();
+    private static HashMap<EntityPlayer, EntityHangGlider> gliderMap = new HashMap<EntityPlayer, EntityHangGlider>();
 
     private IVarioController varioControl = IVarioController.NULL;
 
@@ -60,6 +59,10 @@ public class EntityHangGlider extends Entity implements IEntityAdditionalSpawnDa
     public static boolean isGliderDeployed(Entity player) {
         EntityHangGlider glider = gliderMap.get(player);
         return glider != null && glider.isDeployed();
+    }
+
+    public static EntityHangGlider getEntityHangGlider(Entity player) {
+        return gliderMap.get(player);
     }
 
     private static boolean isGliderValid(EntityPlayer player, EntityHangGlider glider) {

--- a/src/main/java/openblocks/common/item/ItemHangGlider.java
+++ b/src/main/java/openblocks/common/item/ItemHangGlider.java
@@ -1,7 +1,6 @@
 package openblocks.common.item;
 
 import java.util.HashSet;
-import java.util.Map;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
@@ -10,8 +9,6 @@ import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.common.config.Configuration;
 
-import com.google.common.collect.MapMaker;
-
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import openblocks.OpenBlocks;
 import openblocks.common.entity.EntityHangGlider;
@@ -19,9 +16,6 @@ import openmods.infobook.BookDocumentation;
 
 @BookDocumentation(hasVideo = true)
 public class ItemHangGlider extends Item {
-
-    private static final Map<EntityPlayer, EntityHangGlider> spawnedGlidersMap = new MapMaker().weakKeys().weakValues()
-            .makeMap();
 
     private static HashSet<Integer> blacklistedDimensions = new HashSet<>();
 
@@ -103,7 +97,7 @@ public class ItemHangGlider extends Item {
     @Override
     public ItemStack onItemRightClick(ItemStack itemStack, World world, EntityPlayer player) {
         if (!world.isRemote && player != null) {
-            EntityHangGlider glider = spawnedGlidersMap.get(player);
+            EntityHangGlider glider = EntityHangGlider.getEntityHangGlider(player);
             if (glider != null) despawnGlider(player, glider);
             else spawnGlider(player);
         }
@@ -112,7 +106,6 @@ public class ItemHangGlider extends Item {
 
     private static void despawnGlider(EntityPlayer player, EntityHangGlider glider) {
         glider.setDead();
-        spawnedGlidersMap.remove(player);
     }
 
     private static void spawnGlider(EntityPlayer player) {
@@ -124,7 +117,6 @@ public class ItemHangGlider extends Item {
         EntityHangGlider glider = new EntityHangGlider(player.worldObj, player);
         glider.setPositionAndRotation(player.posX, player.posY, player.posZ, player.rotationPitch, player.rotationYaw);
         player.worldObj.spawnEntityInWorld(glider);
-        spawnedGlidersMap.put(player, glider);
     }
 
     private static boolean isInvalidDimension(EntityPlayer player) {


### PR DESCRIPTION
Issue: The OpenBlocks Hang Glider closes when not in your hand anymore (e.g. when scrolling away). But after taking it into your hand again it requires two clicks to open again, instead of one. This happens to me in SP, but I see no reason why it shouldn't happen in MP too.

This happens because the `ItemHangGlider` and `EntityHangGlider` classes use two seperate static maps maintaining all `EntityHangGlider`s in use right now and they did slightly different things. This change reduces this to a single map in `EntityHangGlider` and fixes the above issue.

I believe [Issue 16815](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16815) might also be fixed by this.

This is my first pull request, so if anything is unclear I'm happy to respond :)