### PR TITLE
fix glider won't close on right-click on dedicated server

### DIFF
--- a/src/main/java/openblocks/common/entity/EntityHangGlider.java
+++ b/src/main/java/openblocks/common/entity/EntityHangGlider.java
@@ -61,8 +61,12 @@ public class EntityHangGlider extends Entity implements IEntityAdditionalSpawnDa
         return glider != null && glider.isDeployed();
     }
 
-    public static EntityHangGlider getEntityHangGlider(Entity player) {
+    public static EntityHangGlider getEntityHangGlider(EntityPlayer player) {
         return gliderMap.get(player);
+    }
+
+    public static EntityHangGlider setEntityHangGlider(EntityPlayer player, EntityHangGlider glider) {
+        return gliderMap.put(player, glider);
     }
 
     private static boolean isGliderValid(EntityPlayer player, EntityHangGlider glider) {

--- a/src/main/java/openblocks/common/item/ItemHangGlider.java
+++ b/src/main/java/openblocks/common/item/ItemHangGlider.java
@@ -116,6 +116,7 @@ public class ItemHangGlider extends Item {
 
         EntityHangGlider glider = new EntityHangGlider(player.worldObj, player);
         glider.setPositionAndRotation(player.posX, player.posY, player.posZ, player.rotationPitch, player.rotationYaw);
+        EntityHangGlider.setEntityHangGlider(player, glider);
         player.worldObj.spawnEntityInWorld(glider);
     }
 


### PR DESCRIPTION
Fixes the glider never get closed on right-click in multiplayer. Reason is that it never get stored at the `gliderMap` on servers.

Due #25 the only point where it get written to the `gliderMap` is `readSpawnData()` wich is only executed on the client side.

Thsi PR adds another static method `EntityHangGlider.SetEntityHangGlider(EntityPlayer, EntityHangGlider)` and call it at `ItemHangGlider.spawnGlider()`. This works well in MP & SP.

*(An alternative (and even easier) implentation would be adding the glider to the `gliderMap` on `updateEntity()`. But this doesn't work in SP.)*