### PR TITLE
Fixed glider not closing on right click anymore on servers

### DIFF
--- a/src/main/java/openblocks/common/entity/EntityHangGlider.java
+++ b/src/main/java/openblocks/common/entity/EntityHangGlider.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
-import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -79,7 +78,7 @@ public class EntityHangGlider extends Entity implements IEntityAdditionalSpawnDa
         for (Map.Entry<EntityPlayer, EntityHangGlider> e : gliderMap.entrySet()) {
             EntityPlayer player = e.getKey();
             EntityHangGlider glider = e.getValue();
-            if (isGliderValid(player, glider)) glider.fixPositions(player, player instanceof EntityPlayerSP);
+            if (isGliderValid(player, glider)) glider.fixPositions(player, true);
             else glider.setDead();
         }
     }
@@ -124,6 +123,7 @@ public class EntityHangGlider extends Entity implements IEntityAdditionalSpawnDa
             data.writeInt(-42);
         } else {
             data.writeInt(player.getEntityId());
+            gliderMap.put(player, this);
         }
     }
 

--- a/src/main/java/openblocks/common/entity/EntityHangGlider.java
+++ b/src/main/java/openblocks/common/entity/EntityHangGlider.java
@@ -47,7 +47,7 @@ public class EntityHangGlider extends Entity implements IEntityAdditionalSpawnDa
 
     private static final int PROPERTY_DEPLOYED = 17;
 
-    private static HashMap<EntityPlayer, EntityHangGlider> gliderMap = new HashMap<EntityPlayer, EntityHangGlider>();
+    private static Map<EntityPlayer, EntityHangGlider> gliderMap = new HashMap<>();
 
     private IVarioController varioControl = IVarioController.NULL;
 

--- a/src/main/java/openblocks/common/entity/EntityHangGlider.java
+++ b/src/main/java/openblocks/common/entity/EntityHangGlider.java
@@ -1,6 +1,7 @@
 package openblocks.common.entity;
 
 import java.util.Calendar;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
@@ -11,8 +12,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import net.minecraft.world.gen.NoiseGeneratorPerlin;
-
-import com.google.common.collect.MapMaker;
 
 import cpw.mods.fml.common.registry.IEntityAdditionalSpawnData;
 import cpw.mods.fml.relauncher.Side;
@@ -48,7 +47,7 @@ public class EntityHangGlider extends Entity implements IEntityAdditionalSpawnDa
 
     private static final int PROPERTY_DEPLOYED = 17;
 
-    private static Map<EntityPlayer, EntityHangGlider> gliderMap = new MapMaker().weakKeys().weakValues().makeMap();
+    private static HashMap<EntityPlayer, EntityHangGlider> gliderMap = new HashMap<EntityPlayer, EntityHangGlider>();
 
     private IVarioController varioControl = IVarioController.NULL;
 
@@ -60,6 +59,10 @@ public class EntityHangGlider extends Entity implements IEntityAdditionalSpawnDa
     public static boolean isGliderDeployed(Entity player) {
         EntityHangGlider glider = gliderMap.get(player);
         return glider != null && glider.isDeployed();
+    }
+
+    public static EntityHangGlider getEntityHangGlider(Entity player) {
+        return gliderMap.get(player);
     }
 
     private static boolean isGliderValid(EntityPlayer player, EntityHangGlider glider) {

--- a/src/main/java/openblocks/common/item/ItemHangGlider.java
+++ b/src/main/java/openblocks/common/item/ItemHangGlider.java
@@ -1,7 +1,6 @@
 package openblocks.common.item;
 
 import java.util.HashSet;
-import java.util.Map;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
@@ -10,8 +9,6 @@ import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.common.config.Configuration;
 
-import com.google.common.collect.MapMaker;
-
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import openblocks.OpenBlocks;
 import openblocks.common.entity.EntityHangGlider;
@@ -19,9 +16,6 @@ import openmods.infobook.BookDocumentation;
 
 @BookDocumentation(hasVideo = true)
 public class ItemHangGlider extends Item {
-
-    private static final Map<EntityPlayer, EntityHangGlider> spawnedGlidersMap = new MapMaker().weakKeys().weakValues()
-            .makeMap();
 
     private static HashSet<Integer> blacklistedDimensions = new HashSet<>();
 
@@ -103,7 +97,7 @@ public class ItemHangGlider extends Item {
     @Override
     public ItemStack onItemRightClick(ItemStack itemStack, World world, EntityPlayer player) {
         if (!world.isRemote && player != null) {
-            EntityHangGlider glider = spawnedGlidersMap.get(player);
+            EntityHangGlider glider = EntityHangGlider.getEntityHangGlider(player);
             if (glider != null) despawnGlider(player, glider);
             else spawnGlider(player);
         }
@@ -112,7 +106,6 @@ public class ItemHangGlider extends Item {
 
     private static void despawnGlider(EntityPlayer player, EntityHangGlider glider) {
         glider.setDead();
-        spawnedGlidersMap.remove(player);
     }
 
     private static void spawnGlider(EntityPlayer player) {
@@ -124,7 +117,6 @@ public class ItemHangGlider extends Item {
         EntityHangGlider glider = new EntityHangGlider(player.worldObj, player);
         glider.setPositionAndRotation(player.posX, player.posY, player.posZ, player.rotationPitch, player.rotationYaw);
         player.worldObj.spawnEntityInWorld(glider);
-        spawnedGlidersMap.put(player, glider);
     }
 
     private static boolean isInvalidDimension(EntityPlayer player) {

--- a/src/main/java/openblocks/common/item/ItemHangGlider.java
+++ b/src/main/java/openblocks/common/item/ItemHangGlider.java
@@ -98,14 +98,10 @@ public class ItemHangGlider extends Item {
     public ItemStack onItemRightClick(ItemStack itemStack, World world, EntityPlayer player) {
         if (!world.isRemote && player != null) {
             EntityHangGlider glider = EntityHangGlider.getEntityHangGlider(player);
-            if (glider != null) despawnGlider(player, glider);
+            if (glider != null) glider.setDead();
             else spawnGlider(player);
         }
         return itemStack;
-    }
-
-    private static void despawnGlider(EntityPlayer player, EntityHangGlider glider) {
-        glider.setDead();
     }
 
     private static void spawnGlider(EntityPlayer player) {


### PR DESCRIPTION
Issue: This [PR25](https://github.com/GTNewHorizons/OpenBlocks/pull/25) broke right click beeing able to close the hang glider, but only on dedicated servers.

I'm not a 100% confident in the cause of this, as I do not fully understand what is and is not synced between logical client and logical server and how this differs in the case of a SP world vs a dedicated server.
I believe this happens because `readSpawnData` is only run on the client and this is the only place we add the `EntityHangGlider`-instance to the map after PR25. I do not know, why this would only affect dedicated servers.
This change adds a `gliderMap.put(...)` to the server side to fix this issue.

Another issue then appears (only in SP): The glider floats way above the player, this seems to be usually fixed by the call to `glider.fixPositions` in `updateGliders`. But here the check depends on the type of EntityPlayer object. This might have also been broken by PR25. But as the whole `updateGliders` is `@SideOnly(Side.CLIENT)` it seems sensible to always hand over `localPlayer=true` in the `glider.fixPositions` call here and this change indeed fixes the issue.

I tested these changes in SP and on a dedicated server and everything remarked here and in PR25 now works as it should. Maybe someone with more indepth knowledge of the server/client side system of minecraft can explain what I could not here.