### PR TITLE
Building Guide - Clarity

### DIFF
--- a/src/main/java/openblocks/common/tileentity/TileEntityGuide.java
+++ b/src/main/java/openblocks/common/tileentity/TileEntityGuide.java
@@ -427,15 +427,25 @@ public class TileEntityGuide extends DroppableTileEntity implements ISyncListene
     }
 
     private void notifyPlayer(EntityPlayer player) {
-        player.addChatMessage(
-                new ChatComponentTranslation(
+        boolean is2D = posY.get() == 0 && negY.get() == 0;
+
+        ChatComponentTranslation notification = is2D
+                ? new ChatComponentTranslation(
+                        "openblocks.misc.change_area_size",
+                        -negX.get(),
+                        -negZ.get(),
+                        +posX.get(),
+                        +posZ.get())
+                : new ChatComponentTranslation(
                         "openblocks.misc.change_box_size",
                         -negX.get(),
                         -negY.get(),
                         -negZ.get(),
                         +posX.get(),
                         +posY.get(),
-                        +posZ.get()));
+                        +posZ.get());
+
+        player.addChatMessage(notification);
         displayBlockCount(player);
     }
 

--- a/src/main/resources/assets/openblocks/lang/de_DE.lang
+++ b/src/main/resources/assets/openblocks/lang/de_DE.lang
@@ -89,6 +89,7 @@ openblocks.misc.pointed_cannon=Kanone zielt nun auf %s, %s, %s
 openblocks.misc.change_mode=Wechsle zu %s-Modus
 openblocks.misc.change_size=Ändere Größe zu %sx%sx%s
 openblocks.misc.change_box_size=Ändere Größe zu (%d,%d,%d):(%d,%d,%d)
+openblocks.misc.change_area_size=Ändere Größe zu (%d,%d):(%d,%d)
 openblocks.misc.total_blocks=Insgesamt gezählte Blöcke: %d
 openblocks.misc.get_witched=Werde verhext!
 openblocks.misc.page=Seite %d von %d

--- a/src/main/resources/assets/openblocks/lang/en_US.lang
+++ b/src/main/resources/assets/openblocks/lang/en_US.lang
@@ -89,6 +89,7 @@ openblocks.misc.pointed_cannon=Pointed cannon at %s, %s, %s
 openblocks.misc.change_mode=Changing to %s mode
 openblocks.misc.change_size=Changing size to %sx%sx%s
 openblocks.misc.change_box_size=Changing size to (%d,%d,%d):(%d,%d,%d)
+openblocks.misc.change_area_size=Changing size to (%d,%d):(%d,%d)
 openblocks.misc.total_blocks=Total block count: %d
 openblocks.misc.get_witched=Get witched!
 openblocks.misc.page=Page %d of %d

--- a/src/main/resources/assets/openblocks/lang/es_AR.lang
+++ b/src/main/resources/assets/openblocks/lang/es_AR.lang
@@ -86,6 +86,7 @@ openblocks.misc.pointed_cannon=Cañón apuntado a %s, %s, %s
 openblocks.misc.change_mode=Cambiando a modo %s
 openblocks.misc.change_size=Cambiando tamaño a %sx%sx%s
 #openblocks.misc.change_box_size=Changing size to (%d,%d,%d):(%d,%d,%d) ## NEEDS TRANSLATION ##
+#openblocks.misc.change_area_size=Changing size to (%d,%d):(%d,%d) ## NEEDS TRANSLATION ##
 openblocks.misc.total_blocks=Número Total de Bloques: %d
 openblocks.misc.get_witched=¡Embrújate!
 openblocks.misc.page=Página %d de %d
@@ -273,7 +274,7 @@ tile.openblocks.drawingtable.description=La mesa de dibujo se usa para crear pla
 
 tile.openblocks.grave.name=Tumba
 tile.openblocks.trophy.name=Trofeo
-tile.openblocks.trophy.entity.name=Trofeo de %s 
+tile.openblocks.trophy.entity.name=Trofeo de %s
 tile.openblocks.canvasglass.name=Lienzo de cristal
 tile.openblocks.paintcan.name=Lata de pintura
 

--- a/src/main/resources/assets/openblocks/lang/es_ES.lang
+++ b/src/main/resources/assets/openblocks/lang/es_ES.lang
@@ -86,6 +86,7 @@ openblocks.misc.pointed_cannon=Cañón apuntado a %s, %s, %s
 openblocks.misc.change_mode=Cambiando a modo %s
 openblocks.misc.change_size=Cambiando tamaño a %sx%sx%s
 #openblocks.misc.change_box_size=Changing size to (%d,%d,%d):(%d,%d,%d) ## NEEDS TRANSLATION ##
+#openblocks.misc.change_area_size=Changing size to (%d,%d):(%d,%d) ## NEEDS TRANSLATION ##
 openblocks.misc.total_blocks=Número Total de Bloques: %d
 openblocks.misc.get_witched=¡Embrújate!
 openblocks.misc.page=Página %d de %d
@@ -273,7 +274,7 @@ tile.openblocks.drawingtable.description=La mesa de dibujo se usa para crear pla
 
 tile.openblocks.grave.name=Tumba
 tile.openblocks.trophy.name=Trofeo
-tile.openblocks.trophy.entity.name=Trofeo de %s 
+tile.openblocks.trophy.entity.name=Trofeo de %s
 tile.openblocks.canvasglass.name=Lienzo de cristal
 tile.openblocks.paintcan.name=Lata de pintura
 

--- a/src/main/resources/assets/openblocks/lang/es_MX.lang
+++ b/src/main/resources/assets/openblocks/lang/es_MX.lang
@@ -86,6 +86,7 @@ openblocks.misc.pointed_cannon=Cañón apuntado a %s, %s, %s
 openblocks.misc.change_mode=Cambiando a modo %s
 openblocks.misc.change_size=Cambiando tamaño a %sx%sx%s
 #openblocks.misc.change_box_size=Changing size to (%d,%d,%d):(%d,%d,%d) ## NEEDS TRANSLATION ##
+#openblocks.misc.change_area_size=Changing size to (%d,%d):(%d,%d) ## NEEDS TRANSLATION ##
 openblocks.misc.total_blocks=Número Total de Bloques: %d
 openblocks.misc.get_witched=¡Embrújate!
 openblocks.misc.page=Página %d de %d
@@ -273,7 +274,7 @@ tile.openblocks.drawingtable.description=La mesa de dibujo se usa para crear pla
 
 tile.openblocks.grave.name=Tumba
 tile.openblocks.trophy.name=Trofeo
-tile.openblocks.trophy.entity.name=Trofeo de %s 
+tile.openblocks.trophy.entity.name=Trofeo de %s
 tile.openblocks.canvasglass.name=Lienzo de cristal
 tile.openblocks.paintcan.name=Lata de pintura
 

--- a/src/main/resources/assets/openblocks/lang/es_UY.lang
+++ b/src/main/resources/assets/openblocks/lang/es_UY.lang
@@ -86,6 +86,7 @@ openblocks.misc.pointed_cannon=Cañón apuntado a %s, %s, %s
 openblocks.misc.change_mode=Cambiando a modo %s
 openblocks.misc.change_size=Cambiando tamaño a %sx%sx%s
 #openblocks.misc.change_box_size=Changing size to (%d,%d,%d):(%d,%d,%d) ## NEEDS TRANSLATION ##
+#openblocks.misc.change_area_size=Changing size to (%d,%d):(%d,%d) ## NEEDS TRANSLATION ##
 openblocks.misc.total_blocks=Número Total de Bloques: %d
 openblocks.misc.get_witched=¡Embrújate!
 openblocks.misc.page=Página %d de %d
@@ -273,7 +274,7 @@ tile.openblocks.drawingtable.description=La mesa de dibujo se usa para crear pla
 
 tile.openblocks.grave.name=Tumba
 tile.openblocks.trophy.name=Trofeo
-tile.openblocks.trophy.entity.name=Trofeo de %s 
+tile.openblocks.trophy.entity.name=Trofeo de %s
 tile.openblocks.canvasglass.name=Lienzo de cristal
 tile.openblocks.paintcan.name=Lata de pintura
 

--- a/src/main/resources/assets/openblocks/lang/es_VE.lang
+++ b/src/main/resources/assets/openblocks/lang/es_VE.lang
@@ -86,6 +86,7 @@ openblocks.misc.pointed_cannon=Cañón apuntado a %s, %s, %s
 openblocks.misc.change_mode=Cambiando a modo %s
 openblocks.misc.change_size=Cambiando tamaño a %sx%sx%s
 #openblocks.misc.change_box_size=Changing size to (%d,%d,%d):(%d,%d,%d) ## NEEDS TRANSLATION ##
+#openblocks.misc.change_area_size=Changing size to (%d,%d):(%d,%d) ## NEEDS TRANSLATION ##
 openblocks.misc.total_blocks=Número Total de Bloques: %d
 openblocks.misc.get_witched=¡Embrújate!
 openblocks.misc.page=Página %d de %d
@@ -273,7 +274,7 @@ tile.openblocks.drawingtable.description=La mesa de dibujo se usa para crear pla
 
 tile.openblocks.grave.name=Tumba
 tile.openblocks.trophy.name=Trofeo
-tile.openblocks.trophy.entity.name=Trofeo de %s 
+tile.openblocks.trophy.entity.name=Trofeo de %s
 tile.openblocks.canvasglass.name=Lienzo de cristal
 tile.openblocks.paintcan.name=Lata de pintura
 

--- a/src/main/resources/assets/openblocks/lang/et_EE.lang
+++ b/src/main/resources/assets/openblocks/lang/et_EE.lang
@@ -86,6 +86,7 @@ openblocks.misc.locked=Lukustatud
 #openblocks.misc.change_mode=Changing to %s mode ## NEEDS TRANSLATION ##
 #openblocks.misc.change_size=Changing size to %sx%sx%s ## NEEDS TRANSLATION ##
 #openblocks.misc.change_box_size=Changing size to (%d,%d,%d):(%d,%d,%d) ## NEEDS TRANSLATION ##
+#openblocks.misc.change_area_size=Changing size to (%d,%d):(%d,%d) ## NEEDS TRANSLATION ##
 #openblocks.misc.total_blocks=Total block count: %d ## NEEDS TRANSLATION ##
 #openblocks.misc.get_witched=Get witched! ## NEEDS TRANSLATION ##
 #openblocks.misc.page=Page %d of %d ## NEEDS TRANSLATION ##

--- a/src/main/resources/assets/openblocks/lang/fr_FR.lang
+++ b/src/main/resources/assets/openblocks/lang/fr_FR.lang
@@ -86,6 +86,7 @@ openblocks.misc.pointed_cannon=Pointed cannon at %s, %s, %s
 openblocks.misc.change_mode=Changing to %s mode
 openblocks.misc.change_size=Changing size to %sx%sx%s
 #openblocks.misc.change_box_size=Changing size to (%d,%d,%d):(%d,%d,%d) ## NEEDS TRANSLATION ##
+#openblocks.misc.change_area_size=Changing size to (%d,%d):(%d,%d) ## NEEDS TRANSLATION ##
 openblocks.misc.total_blocks=Total block count: %d
 openblocks.misc.get_witched=Get witched!
 openblocks.misc.page=Page %d of %d

--- a/src/main/resources/assets/openblocks/lang/it_IT.lang
+++ b/src/main/resources/assets/openblocks/lang/it_IT.lang
@@ -86,6 +86,7 @@ openblocks.misc.pointed_cannon=Cannone puntato su %s, %s, %s
 openblocks.misc.change_mode=Cambiando modalità a %s
 openblocks.misc.change_size=Modificando dimensione in %sx%sx%s
 openblocks.misc.change_box_size=Modificando dimensione in (%d,%d,%d):(%d,%d,%d)
+openblocks.misc.change_area_size=Modificando dimensione in (%d,%d):(%d,%d)
 openblocks.misc.total_blocks=Conto totale blocchi: %d
 openblocks.misc.get_witched=Diventa stregato!
 openblocks.misc.page=Pagina %d di %d

--- a/src/main/resources/assets/openblocks/lang/ko_KR.lang
+++ b/src/main/resources/assets/openblocks/lang/ko_KR.lang
@@ -86,6 +86,7 @@ openblocks.misc.pointed_cannon=대포의 발사위치 %s, %s, %s
 openblocks.misc.change_mode=%s 모드로 변경
 openblocks.misc.change_size=%sx%sx%s크기로 변경
 #openblocks.misc.change_box_size=Changing size to (%d,%d,%d):(%d,%d,%d) ## NEEDS TRANSLATION ##
+#openblocks.misc.change_area_size=Changing size to (%d,%d):(%d,%d) ## NEEDS TRANSLATION ##
 openblocks.misc.total_blocks=총 블럭 갯수: %d
 openblocks.misc.get_witched=마녀를 얻었다!
 openblocks.misc.page=%d 중 %d 페이지

--- a/src/main/resources/assets/openblocks/lang/nl_NL.lang
+++ b/src/main/resources/assets/openblocks/lang/nl_NL.lang
@@ -86,6 +86,7 @@ openblocks.gui.sprinkler=Sproeier
 #openblocks.misc.change_mode=Changing to %s mode ## NEEDS TRANSLATION ##
 #openblocks.misc.change_size=Changing size to %sx%sx%s ## NEEDS TRANSLATION ##
 #openblocks.misc.change_box_size=Changing size to (%d,%d,%d):(%d,%d,%d) ## NEEDS TRANSLATION ##
+#openblocks.misc.change_area_size=Changing size to (%d,%d):(%d,%d) ## NEEDS TRANSLATION ##
 #openblocks.misc.total_blocks=Total block count: %d ## NEEDS TRANSLATION ##
 #openblocks.misc.get_witched=Get witched! ## NEEDS TRANSLATION ##
 #openblocks.misc.page=Page %d of %d ## NEEDS TRANSLATION ##

--- a/src/main/resources/assets/openblocks/lang/pl_PL.lang
+++ b/src/main/resources/assets/openblocks/lang/pl_PL.lang
@@ -86,6 +86,7 @@ openblocks.misc.locked=Zablokowany
 #openblocks.misc.change_mode=Changing to %s mode ## NEEDS TRANSLATION ##
 #openblocks.misc.change_size=Changing size to %sx%sx%s ## NEEDS TRANSLATION ##
 #openblocks.misc.change_box_size=Changing size to (%d,%d,%d):(%d,%d,%d) ## NEEDS TRANSLATION ##
+#openblocks.misc.change_area_size=Changing size to (%d,%d):(%d,%d) ## NEEDS TRANSLATION ##
 #openblocks.misc.total_blocks=Total block count: %d ## NEEDS TRANSLATION ##
 #openblocks.misc.get_witched=Get witched! ## NEEDS TRANSLATION ##
 #openblocks.misc.page=Page %d of %d ## NEEDS TRANSLATION ##

--- a/src/main/resources/assets/openblocks/lang/pt_BR.lang
+++ b/src/main/resources/assets/openblocks/lang/pt_BR.lang
@@ -86,6 +86,7 @@ openblocks.misc.mode.inverted_stairs=Escadas invertidas
 #openblocks.misc.change_mode=Changing to %s mode ## NEEDS TRANSLATION ##
 #openblocks.misc.change_size=Changing size to %sx%sx%s ## NEEDS TRANSLATION ##
 #openblocks.misc.change_box_size=Changing size to (%d,%d,%d):(%d,%d,%d) ## NEEDS TRANSLATION ##
+#openblocks.misc.change_area_size=Changing size to (%d,%d):(%d,%d) ## NEEDS TRANSLATION ##
 #openblocks.misc.total_blocks=Total block count: %d ## NEEDS TRANSLATION ##
 #openblocks.misc.get_witched=Get witched! ## NEEDS TRANSLATION ##
 #openblocks.misc.page=Page %d of %d ## NEEDS TRANSLATION ##

--- a/src/main/resources/assets/openblocks/lang/ru_RU.lang
+++ b/src/main/resources/assets/openblocks/lang/ru_RU.lang
@@ -86,6 +86,7 @@ openblocks.misc.pointed_cannon=Пушка направлена на %s, %s, %s
 openblocks.misc.change_mode=Изменение режима на %s
 openblocks.misc.change_size=Изменение размера на %sx%sx%s
 #openblocks.misc.change_box_size=Changing size to (%d,%d,%d):(%d,%d,%d) ## NEEDS TRANSLATION ##
+#openblocks.misc.change_area_size=Changing size to (%d,%d):(%d,%d) ## NEEDS TRANSLATION ##
 openblocks.misc.total_blocks=Общее количество блоков: %d
 openblocks.misc.get_witched=Get witched!
 openblocks.misc.page=Страница %d из %d

--- a/src/main/resources/assets/openblocks/lang/zh_CN.lang
+++ b/src/main/resources/assets/openblocks/lang/zh_CN.lang
@@ -89,6 +89,7 @@ openblocks.misc.pointed_cannon=加农炮已瞄准 %s, %s, %s
 openblocks.misc.change_mode=改变至%s模式
 openblocks.misc.change_size=改变规模至 %s x %s x %s
 openblocks.misc.change_box_size=Changing size to (%d,%d,%d):(%d,%d,%d)
+openblocks.misc.change_area_size=Changing size to (%d,%d):(%d,%d)
 openblocks.misc.total_blocks=搭建共需要: %d 个方块
 openblocks.misc.get_witched=为之沉迷!
 openblocks.misc.page=%d / %d 页


### PR DESCRIPTION
The Building Guide notification now omits relative altitudes (Y) in its notification if its area of operation is in 2D (1 Block tall):

> **Working with a Square:**
> Changing size to (-2,-2):(+2,+2)

> **Working with a Cube:**
> Changing size to (-2,-2,-2):(+2,+2,+2)

This should better hint to players that those 2 sets of 3 numbers spammed in chat are relative coordinates (~80% players have no clue)