### PR TITLE
In-game documentation should document

### DIFF
--- a/src/main/resources/assets/openblocks/lang/en_US.lang
+++ b/src/main/resources/assets/openblocks/lang/en_US.lang
@@ -188,7 +188,7 @@ tile.openblocks.heal.name=Healer
 tile.openblocks.heal.description=The healing block is a creative-mode only block that gives off a slight healing effect over time.
 
 tile.openblocks.guide.name=Building Guide
-tile.openblocks.guide.description=The building guide is a redstone device that projects shapes using ghost blocks for easier building. The top face cycles through or rotate the shape. The side face has one set of buttons for each direction: +/– adjusts direction length while ➤ mirrors it to its opposing direction.\nProjection color can be changed by using dye on the building guide.
+tile.openblocks.guide.description=The building guide projects shapes using ghost blocks for easier building. Projection is activated via redstone signal and configured with an empty hand by using the buttons on each face. The top face cycles through or rotates the shape. The side face has one set of buttons for each direction (up, down, left & right): +/– adjusts direction length while ➤ mirrors it to its opposing direction.\nProjection color can be changed by using dye on the building guide.
 
 tile.openblocks.builder_guide.name=Enhanced Building Guide
 tile.openblocks.builder_guide.description=This enhanced version of building guide not only displays ghost blocks to make building easier, but also allows you to place actual blocks. Just click central block with any block stack!\nWhen in creative mode you can place an obsidian block above, then hit the building guide with any block you like to automatically create the shape.

--- a/src/main/resources/assets/openblocks/lang/en_US.lang
+++ b/src/main/resources/assets/openblocks/lang/en_US.lang
@@ -188,7 +188,7 @@ tile.openblocks.heal.name=Healer
 tile.openblocks.heal.description=The healing block is a creative-mode only block that gives off a slight healing effect over time.
 
 tile.openblocks.guide.name=Building Guide
-tile.openblocks.guide.description=The building guide projects shapes using ghost blocks for easier building. Projection is activated via redstone signal and configured with an empty hand by using the buttons on each face. The top face cycles through or rotates the shape. The side face has one set of buttons for each direction (up, down, left & right): +/– adjusts direction length while ➤ mirrors it to its opposing direction.\nProjection color can be changed by using dye on the building guide.
+tile.openblocks.guide.description=The building guide projects shapes using ghost blocks for easier building. Projection is activated via Redstone signal and configured with an empty hand by using the buttons on each face. The top face cycles through or rotates the shape. The side face has one set of buttons for each direction (up, down, left & right): +/– adjusts direction length while ➤ mirrors it to its opposing direction.\nProjection color can be changed by using Dye on the building guide.
 
 tile.openblocks.builder_guide.name=Enhanced Building Guide
 tile.openblocks.builder_guide.description=This enhanced version of building guide not only displays ghost blocks to make building easier, but also allows you to place actual blocks. Just click central block with any block stack!\nWhen in creative mode you can place an obsidian block above, then hit the building guide with any block you like to automatically create the shape.

--- a/src/main/resources/assets/openblocks/lang/en_US.lang
+++ b/src/main/resources/assets/openblocks/lang/en_US.lang
@@ -188,7 +188,7 @@ tile.openblocks.heal.name=Healer
 tile.openblocks.heal.description=The healing block is a creative-mode only block that gives off a slight healing effect over time.
 
 tile.openblocks.guide.name=Building Guide
-tile.openblocks.guide.description=The building guide, once powered with redstone, will give you an outline of ghost blocks in different shapes and sizes that'll help you plan out rooms.\nUse touch-buttons on block to change outline dimensions and shapes.\nColor of markers can be changed by using dye on central block.
+tile.openblocks.guide.description=The building guide is a redstone device that projects shapes using ghost blocks for easier building. The top face cycles through or rotate the shape. The side face has one set of buttons for each direction: +/– adjusts direction length while ➤ mirrors it to its opposing direction.\nProjection color can be changed by using dye on the building guide.
 
 tile.openblocks.builder_guide.name=Enhanced Building Guide
 tile.openblocks.builder_guide.description=This enhanced version of building guide not only displays ghost blocks to make building easier, but also allows you to place actual blocks. Just click central block with any block stack!\nWhen in creative mode you can place an obsidian block above, then hit the building guide with any block you like to automatically create the shape.


### PR DESCRIPTION
I don't want to write quests for mods that have already in-game guides so I am replacing the flavour text with in-game documentation.

Changes: Add actual instructions as concisely as possible to the in-game guide, including, but not limited to, what every button does.

Note: We use ➤ because it is actually visible in smaller GUI sizes compared to >

**Before:**
> The building guide, once powered with redstone, will give you an outline of ghost blocks in different shapes and sizes that'll help you plan out rooms. Use touch-buttons on block to change outline dimensions and shapes. 
> Color of markers can be changed by using dye on central block.

**After:**
<img width="412" height="337" alt="image" src="https://github.com/user-attachments/assets/7e8d5978-e43c-4bbe-8153-0aafb72e2e8a" />
