### PR TITLE
Add GalactiCraft gear auto-equip from grave

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,19 +3,22 @@
 dependencies {
     api('com.github.GTNewHorizons:OpenModsLib:0.10.14:dev')
 
-    devOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.8.98-GTNH:dev')
     compileOnly('openperipheral:OpenPeripheralCore-API:3.4.1')
     compileOnly('curse.maven:computercraft-67504:2269339')
-    compileOnly('com.github.GTNewHorizons:Mobs-Info:0.5.14-GTNH:dev')
+    compileOnly('com.github.GTNewHorizons:Mobs-Info:0.5.17-GTNH:dev')
     compileOnly("com.github.GTNewHorizons:Backhand:1.8.10:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Baubles-Expanded:2.2.19-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:AdventureBackpack2:1.4.19-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Minecraft-Backpack-Mod:2.6.12-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.14.73-GTNH:dev") { transitive = false }
-    devOnlyNonPublishable("com.github.GTNewHorizons:Baubles-Expanded:2.2.19-GTNH:dev") { transitive = false }
-    devOnlyNonPublishable("com.github.GTNewHorizons:AdventureBackpack2:1.4.19-GTNH:dev") { transitive = false }
-    devOnlyNonPublishable("com.github.GTNewHorizons:Minecraft-Backpack-Mod:2.6.12-GTNH:dev") { transitive = false }
-    devOnlyNonPublishable("com.github.GTNewHorizons:TinkersConstruct:1.14.73-GTNH:dev") { transitive = true }
-    devOnlyNonPublishable("com.github.GTNewHorizons:waila:1.19.28:dev") { transitive = true }
+    compileOnly("com.github.GTNewHorizons:Baubles-Expanded:2.2.21-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:AdventureBackpack2:1.4.21-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Minecraft-Backpack-Mod:2.6.13-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.14.91-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Galacticraft:3.4.29-GTNH:dev") { transitive = false }
+
+    devOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.8.101-GTNH:dev')
+    devOnlyNonPublishable("com.github.GTNewHorizons:Baubles-Expanded:2.2.21-GTNH:dev") { transitive = false }
+    devOnlyNonPublishable("com.github.GTNewHorizons:AdventureBackpack2:1.4.21-GTNH:dev") { transitive = false }
+    devOnlyNonPublishable("com.github.GTNewHorizons:Minecraft-Backpack-Mod:2.6.13-GTNH:dev") { transitive = false }
+    devOnlyNonPublishable("com.github.GTNewHorizons:TinkersConstruct:1.14.91-GTNH:dev") { transitive = true }
+    devOnlyNonPublishable("com.github.GTNewHorizons:waila:1.19.30:dev") { transitive = true }
     devOnlyNonPublishable("com.github.GTNewHorizons:HoloInventory:2.5.13-GTNH:dev") { transitive = true }
+    devOnlyNonPublishable("com.github.GTNewHorizons:Galacticraft:3.4.29-GTNH:dev") { transitive = false }
 }

--- a/src/main/java/openblocks/common/GraveAutoEquip.java
+++ b/src/main/java/openblocks/common/GraveAutoEquip.java
@@ -1,11 +1,30 @@
 package openblocks.common;
 
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemStack;
 
+import com.darkona.adventurebackpack.item.IBackWearableItem;
+import com.darkona.adventurebackpack.playerProperties.BackpackProperty;
+
+import baubles.api.BaublesApi;
+import baubles.api.IBauble;
+import de.eydamos.backpack.item.ItemBackpackBase;
+import de.eydamos.backpack.saves.PlayerSave;
+import micdoodle8.mods.galacticraft.api.item.IItemThermal;
+import micdoodle8.mods.galacticraft.core.entities.player.GCPlayerStats;
+import micdoodle8.mods.galacticraft.core.inventory.InventoryExtended;
+import micdoodle8.mods.galacticraft.core.items.GCItems;
+import micdoodle8.mods.galacticraft.core.items.ItemOxygenMask;
+import micdoodle8.mods.galacticraft.core.items.ItemOxygenTank;
+import micdoodle8.mods.galacticraft.core.items.ItemParaChute;
 import openmods.Log;
+import tconstruct.armor.player.ArmorExtended;
+import tconstruct.armor.player.TPlayerStats;
+import tconstruct.library.accessory.IAccessory;
+import tconstruct.util.config.PHConstruct;
 
 public class GraveAutoEquip {
 
@@ -15,22 +34,16 @@ public class GraveAutoEquip {
     public static boolean tryRestoreToOrigin(EntityPlayer player, ItemStack stack, GraveSlotOrigin origin) {
         if (stack == null || origin == null) return false;
         try {
-            switch (origin.inventoryType) {
-                case GraveSlotOrigin.INV_MAIN:
-                    return restoreToMain(player, stack, origin.slot);
-                case GraveSlotOrigin.INV_ARMOR:
-                    return restoreToArmor(player, stack, origin.slot);
-                case GraveSlotOrigin.INV_TCONSTRUCT:
-                    return restoreToTConstruct(player, stack, origin.slot);
-                case GraveSlotOrigin.INV_BAUBLES:
-                    return restoreToBaubles(player, stack, origin.slot);
-                case GraveSlotOrigin.INV_ADVENTURE_BACKPACK:
-                    return restoreToAdventureBackpack(player, stack);
-                case GraveSlotOrigin.INV_MC_BACKPACK:
-                    return restoreToMcBackpack(player, stack);
-                default:
-                    return false;
-            }
+            return switch (origin.inventoryType) {
+                case GraveSlotOrigin.INV_MAIN -> restoreToMain(player, stack, origin.slot);
+                case GraveSlotOrigin.INV_ARMOR -> restoreToArmor(player, stack, origin.slot);
+                case GraveSlotOrigin.INV_TCONSTRUCT -> restoreToTConstruct(player, stack, origin.slot);
+                case GraveSlotOrigin.INV_BAUBLES -> restoreToBaubles(player, stack, origin.slot);
+                case GraveSlotOrigin.INV_ADVENTURE_BACKPACK -> restoreToAdventureBackpack(player, stack);
+                case GraveSlotOrigin.INV_MC_BACKPACK -> restoreToMcBackpack(player, stack);
+                case GraveSlotOrigin.INV_GALACTICRAFT -> restoreToGalacticraft(player, stack, origin.slot);
+                default -> false;
+            };
         } catch (Exception e) {
             Log.warn(
                     "GraveAutoEquip: error restoring %s to origin %s/%d: %s",
@@ -64,7 +77,7 @@ public class GraveAutoEquip {
     private static final class BaublesRestoreHelper {
 
         static boolean restore(EntityPlayer player, ItemStack stack, int slot) {
-            IInventory inv = baubles.api.BaublesApi.getBaubles(player);
+            IInventory inv = BaublesApi.getBaubles(player);
             if (inv == null) return false;
             if (slot < 0 || slot >= inv.getSizeInventory()) return false;
             if (inv.getStackInSlot(slot) != null) return false;
@@ -81,14 +94,12 @@ public class GraveAutoEquip {
     private static final class AdventureBackpackRestoreHelper {
 
         static boolean restore(EntityPlayer player, ItemStack stack) {
-            if (!(stack.getItem() instanceof com.darkona.adventurebackpack.item.IBackWearableItem)) return false;
-            com.darkona.adventurebackpack.playerProperties.BackpackProperty prop = com.darkona.adventurebackpack.playerProperties.BackpackProperty
-                    .get(player);
+            if (!(stack.getItem() instanceof IBackWearableItem)) return false;
+            BackpackProperty prop = BackpackProperty.get(player);
             if (prop == null || prop.getWearable() != null) return false;
             prop.setWearable(stack.copy());
-            ((com.darkona.adventurebackpack.item.IBackWearableItem) stack.getItem())
-                    .onEquipped(player.worldObj, player, stack);
-            com.darkona.adventurebackpack.playerProperties.BackpackProperty.sync(player);
+            ((IBackWearableItem) stack.getItem()).onEquipped(player.worldObj, player, stack);
+            BackpackProperty.sync(player);
             return true;
         }
     }
@@ -101,8 +112,8 @@ public class GraveAutoEquip {
     private static final class McBackpackRestoreHelper {
 
         static boolean restore(EntityPlayer player, ItemStack stack) {
-            if (!(stack.getItem() instanceof de.eydamos.backpack.item.ItemBackpackBase)) return false;
-            de.eydamos.backpack.saves.PlayerSave save = new de.eydamos.backpack.saves.PlayerSave(player);
+            if (!(stack.getItem() instanceof ItemBackpackBase)) return false;
+            PlayerSave save = new PlayerSave(player);
             if (save.hasPersonalBackpack()) return false;
             save.setPersonalBackpack(stack.copy());
             return true;
@@ -169,7 +180,7 @@ public class GraveAutoEquip {
         static boolean isTabEnabled() {
             try {
                 // enableTinkerInventoryTab is available only since TConstruct 1.14.72-GTNH
-                return tconstruct.util.config.PHConstruct.enableTinkerInventoryTab;
+                return PHConstruct.enableTinkerInventoryTab;
             } catch (NoSuchFieldError e) {
                 return true;
             }
@@ -184,12 +195,11 @@ public class GraveAutoEquip {
     private static final class TConstructAccessoryHelper {
 
         static boolean equip(EntityPlayer player, ItemStack stack) {
-            if (!(stack.getItem() instanceof tconstruct.library.accessory.IAccessory)) return false;
-            tconstruct.library.accessory.IAccessory accessory = (tconstruct.library.accessory.IAccessory) stack
-                    .getItem();
-            tconstruct.armor.player.TPlayerStats stats = tconstruct.armor.player.TPlayerStats.get(player);
+            if (!(stack.getItem() instanceof IAccessory)) return false;
+            IAccessory accessory = (IAccessory) stack.getItem();
+            TPlayerStats stats = TPlayerStats.get(player);
             if (stats == null) return false;
-            tconstruct.armor.player.ArmorExtended armor = stats.armor;
+            ArmorExtended armor = stats.armor;
             for (int i = 0; i < armor.getSizeInventory(); i++) {
                 if (armor.getStackInSlot(i) == null && accessory.canEquipAccessory(stack, i)) {
                     armor.setInventorySlotContents(i, stack.copy());
@@ -208,9 +218,9 @@ public class GraveAutoEquip {
     private static final class TConstructRestoreHelper {
 
         static boolean restore(EntityPlayer player, ItemStack stack, int slot) {
-            tconstruct.armor.player.TPlayerStats stats = tconstruct.armor.player.TPlayerStats.get(player);
+            TPlayerStats stats = TPlayerStats.get(player);
             if (stats == null) return false;
-            tconstruct.armor.player.ArmorExtended armor = stats.armor;
+            ArmorExtended armor = stats.armor;
             if (slot < 0 || slot >= armor.getSizeInventory()) return false;
             if (armor.getStackInSlot(slot) != null) return false;
             armor.setInventorySlotContents(slot, stack.copy());
@@ -245,8 +255,8 @@ public class GraveAutoEquip {
     private static final class BaubleEquipHelper {
 
         static boolean equip(EntityPlayer player, ItemStack stack) {
-            if (!(stack.getItem() instanceof baubles.api.IBauble)) return false;
-            IInventory inv = baubles.api.BaublesApi.getBaubles(player);
+            if (!(stack.getItem() instanceof IBauble)) return false;
+            IInventory inv = BaublesApi.getBaubles(player);
             if (inv == null) return false;
             for (int i = 0; i < inv.getSizeInventory(); i++) {
                 if (inv.getStackInSlot(i) == null && inv.isItemValidForSlot(i, stack)) {
@@ -270,14 +280,12 @@ public class GraveAutoEquip {
     private static final class AdventureBackpackEquipHelper {
 
         static boolean equip(EntityPlayer player, ItemStack stack) {
-            if (!(stack.getItem() instanceof com.darkona.adventurebackpack.item.IBackWearableItem)) return false;
-            com.darkona.adventurebackpack.playerProperties.BackpackProperty prop = com.darkona.adventurebackpack.playerProperties.BackpackProperty
-                    .get(player);
+            if (!(stack.getItem() instanceof IBackWearableItem)) return false;
+            BackpackProperty prop = BackpackProperty.get(player);
             if (prop == null || prop.getWearable() != null) return false;
             prop.setWearable(stack.copy());
-            ((com.darkona.adventurebackpack.item.IBackWearableItem) stack.getItem())
-                    .onEquipped(player.worldObj, player, stack);
-            com.darkona.adventurebackpack.playerProperties.BackpackProperty.sync(player);
+            ((IBackWearableItem) stack.getItem()).onEquipped(player.worldObj, player, stack);
+            BackpackProperty.sync(player);
             return true;
         }
     }
@@ -294,10 +302,29 @@ public class GraveAutoEquip {
     private static final class McBackpackEquipHelper {
 
         static boolean equip(EntityPlayer player, ItemStack stack) {
-            if (!(stack.getItem() instanceof de.eydamos.backpack.item.ItemBackpackBase)) return false;
-            de.eydamos.backpack.saves.PlayerSave save = new de.eydamos.backpack.saves.PlayerSave(player);
+            if (!(stack.getItem() instanceof ItemBackpackBase)) return false;
+            PlayerSave save = new PlayerSave(player);
             if (save.hasPersonalBackpack()) return false;
             save.setPersonalBackpack(stack.copy());
+            return true;
+        }
+    }
+
+    private static boolean restoreToGalacticraft(EntityPlayer player, ItemStack stack, int slot) {
+        if (!ModPresence.GALACTICRAFT) return false;
+        return GalacticraftRestoreHelper.restore(player, stack, slot);
+    }
+
+    private static final class GalacticraftRestoreHelper {
+
+        static boolean restore(EntityPlayer player, ItemStack stack, int slot) {
+            if (!(player instanceof EntityPlayerMP)) return false;
+            GCPlayerStats stats = GCPlayerStats.get((EntityPlayerMP) player);
+            if (stats == null) return false;
+            InventoryExtended inv = stats.extendedInventory;
+            if (slot < 0 || slot >= inv.getSizeInventory()) return false;
+            if (inv.getStackInSlot(slot) != null) return false;
+            inv.setInventorySlotContents(slot, stack.copy());
             return true;
         }
     }
@@ -314,11 +341,10 @@ public class GraveAutoEquip {
     private static final class GalacticraftEquipHelper {
 
         static boolean equip(EntityPlayer player, ItemStack stack) {
-            if (!(player instanceof net.minecraft.entity.player.EntityPlayerMP)) return false;
-            micdoodle8.mods.galacticraft.core.entities.player.GCPlayerStats stats = micdoodle8.mods.galacticraft.core.entities.player.GCPlayerStats
-                    .get((net.minecraft.entity.player.EntityPlayerMP) player);
+            if (!(player instanceof EntityPlayerMP)) return false;
+            GCPlayerStats stats = GCPlayerStats.get((EntityPlayerMP) player);
             if (stats == null) return false;
-            micdoodle8.mods.galacticraft.core.inventory.InventoryExtended inv = stats.extendedInventory;
+            InventoryExtended inv = stats.extendedInventory;
             for (int i = 0; i < inv.getSizeInventory(); i++) {
                 if (inv.getStackInSlot(i) == null && isValidForSlot(stack, i)) {
                     inv.setInventorySlotContents(i, stack.copy());
@@ -330,36 +356,24 @@ public class GraveAutoEquip {
 
         /** Mirrors SlotExtendedInventory.isItemValid logic without depending on the slot class. */
         private static boolean isValidForSlot(ItemStack stack, int slot) {
-            switch (slot) {
-                case 0:
-                    return stack.getItem() instanceof micdoodle8.mods.galacticraft.core.items.ItemOxygenMask;
-                case 1:
-                    return stack.getItem() == micdoodle8.mods.galacticraft.core.items.GCItems.oxygenGear;
-                case 2:
-                case 3:
-                    return stack.getItem() instanceof micdoodle8.mods.galacticraft.core.items.ItemOxygenTank;
-                case 4:
-                    return stack.getItem() instanceof micdoodle8.mods.galacticraft.core.items.ItemParaChute;
-                case 5:
-                    return stack.getItem() == micdoodle8.mods.galacticraft.core.items.GCItems.basicItem
-                            && stack.getItemDamage() == 19;
-                case 6:
-                    return isThermalValid(stack, 0);
-                case 7:
-                    return isThermalValid(stack, 1);
-                case 8:
-                    return isThermalValid(stack, 2);
-                case 9:
-                    return isThermalValid(stack, 3);
-                default:
-                    return false;
-            }
+            return switch (slot) {
+                case 0 -> stack.getItem() instanceof ItemOxygenMask;
+                case 1 -> stack.getItem() == GCItems.oxygenGear;
+                case 2, 3 -> stack.getItem() instanceof ItemOxygenTank;
+                case 4 -> stack.getItem() instanceof ItemParaChute;
+                case 5 -> stack.getItem() == GCItems.basicItem && stack.getItemDamage() == 19; // damage=19 is Frequency
+                                                                                               // Module
+                case 6 -> isThermalValid(stack, 0);
+                case 7 -> isThermalValid(stack, 1);
+                case 8 -> isThermalValid(stack, 2);
+                case 9 -> isThermalValid(stack, 3);
+                default -> false;
+            };
         }
 
         private static boolean isThermalValid(ItemStack stack, int slotIndex) {
-            if (!(stack.getItem() instanceof micdoodle8.mods.galacticraft.api.item.IItemThermal)) return false;
-            return ((micdoodle8.mods.galacticraft.api.item.IItemThermal) stack.getItem())
-                    .isValidForSlot(stack, slotIndex);
+            if (!(stack.getItem() instanceof IItemThermal thermal)) return false;
+            return thermal.isValidForSlot(stack, slotIndex);
         }
     }
 }

--- a/src/main/java/openblocks/common/GraveAutoEquip.java
+++ b/src/main/java/openblocks/common/GraveAutoEquip.java
@@ -146,6 +146,12 @@ public class GraveAutoEquip {
             Log.warn("GraveAutoEquip: error equipping mc backpack %s: %s", stack.getDisplayName(), e);
         }
 
+        try {
+            if (tryEquipGalacticraft(player, stack)) return null;
+        } catch (Exception e) {
+            Log.warn("GraveAutoEquip: error equipping galacticraft gear %s: %s", stack.getDisplayName(), e);
+        }
+
         return stack;
     }
 
@@ -293,6 +299,67 @@ public class GraveAutoEquip {
             if (save.hasPersonalBackpack()) return false;
             save.setPersonalBackpack(stack.copy());
             return true;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // GalactiCraft extended inventory (soft dependency)
+    // -------------------------------------------------------------------------
+
+    private static boolean tryEquipGalacticraft(EntityPlayer player, ItemStack stack) {
+        if (!ModPresence.GALACTICRAFT) return false;
+        return GalacticraftEquipHelper.equip(player, stack);
+    }
+
+    private static final class GalacticraftEquipHelper {
+
+        static boolean equip(EntityPlayer player, ItemStack stack) {
+            if (!(player instanceof net.minecraft.entity.player.EntityPlayerMP)) return false;
+            micdoodle8.mods.galacticraft.core.entities.player.GCPlayerStats stats = micdoodle8.mods.galacticraft.core.entities.player.GCPlayerStats
+                    .get((net.minecraft.entity.player.EntityPlayerMP) player);
+            if (stats == null) return false;
+            micdoodle8.mods.galacticraft.core.inventory.InventoryExtended inv = stats.extendedInventory;
+            for (int i = 0; i < inv.getSizeInventory(); i++) {
+                if (inv.getStackInSlot(i) == null && isValidForSlot(stack, i)) {
+                    inv.setInventorySlotContents(i, stack.copy());
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /** Mirrors SlotExtendedInventory.isItemValid logic without depending on the slot class. */
+        private static boolean isValidForSlot(ItemStack stack, int slot) {
+            switch (slot) {
+                case 0:
+                    return stack.getItem() instanceof micdoodle8.mods.galacticraft.core.items.ItemOxygenMask;
+                case 1:
+                    return stack.getItem() == micdoodle8.mods.galacticraft.core.items.GCItems.oxygenGear;
+                case 2:
+                case 3:
+                    return stack.getItem() instanceof micdoodle8.mods.galacticraft.core.items.ItemOxygenTank;
+                case 4:
+                    return stack.getItem() instanceof micdoodle8.mods.galacticraft.core.items.ItemParaChute;
+                case 5:
+                    return stack.getItem() == micdoodle8.mods.galacticraft.core.items.GCItems.basicItem
+                            && stack.getItemDamage() == 19;
+                case 6:
+                    return isThermalValid(stack, 0);
+                case 7:
+                    return isThermalValid(stack, 1);
+                case 8:
+                    return isThermalValid(stack, 2);
+                case 9:
+                    return isThermalValid(stack, 3);
+                default:
+                    return false;
+            }
+        }
+
+        private static boolean isThermalValid(ItemStack stack, int slotIndex) {
+            if (!(stack.getItem() instanceof micdoodle8.mods.galacticraft.api.item.IItemThermal)) return false;
+            return ((micdoodle8.mods.galacticraft.api.item.IItemThermal) stack.getItem())
+                    .isValidForSlot(stack, slotIndex);
         }
     }
 }

--- a/src/main/java/openblocks/common/GraveInventorySnapshot.java
+++ b/src/main/java/openblocks/common/GraveInventorySnapshot.java
@@ -4,6 +4,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import baubles.api.BaublesApi;
+import com.darkona.adventurebackpack.playerProperties.BackpackProperty;
+import de.eydamos.backpack.saves.PlayerSave;
+import micdoodle8.mods.galacticraft.core.entities.player.GCPlayerStats;
+import micdoodle8.mods.galacticraft.core.inventory.InventoryExtended;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -12,6 +17,9 @@ import net.minecraft.item.ItemStack;
 
 import openmods.Log;
 import openmods.inventory.GenericInventory;
+import tconstruct.armor.player.ArmorExtended;
+import tconstruct.armor.player.TPlayerStats;
+import tconstruct.util.config.PHConstruct;
 
 public class GraveInventorySnapshot {
 
@@ -69,16 +77,16 @@ public class GraveInventorySnapshot {
         static boolean isTabEnabled() {
             try {
                 // enableTinkerInventoryTab is available only since TConstruct 1.14.72-GTNH
-                return tconstruct.util.config.PHConstruct.enableTinkerInventoryTab;
+                return PHConstruct.enableTinkerInventoryTab;
             } catch (NoSuchFieldError e) {
                 return true;
             }
         }
 
         static void capture(EntityPlayer player, List<OriginatedStack> out) {
-            tconstruct.armor.player.TPlayerStats stats = tconstruct.armor.player.TPlayerStats.get(player);
+            TPlayerStats stats = TPlayerStats.get(player);
             if (stats == null) return;
-            tconstruct.armor.player.ArmorExtended armor = stats.armor;
+            ArmorExtended armor = stats.armor;
             for (int i = 0; i < armor.getSizeInventory(); i++) {
                 ItemStack stack = armor.getStackInSlot(i);
                 if (stack != null)
@@ -99,7 +107,7 @@ public class GraveInventorySnapshot {
     private static final class BaublesCaptureHelper {
 
         static void capture(EntityPlayer player, List<OriginatedStack> out) {
-            IInventory inv = baubles.api.BaublesApi.getBaubles(player);
+            IInventory inv = BaublesApi.getBaubles(player);
             if (inv == null) return;
             for (int i = 0; i < inv.getSizeInventory(); i++) {
                 ItemStack stack = inv.getStackInSlot(i);
@@ -121,7 +129,7 @@ public class GraveInventorySnapshot {
     private static final class AdventureBackpackCaptureHelper {
 
         static void capture(EntityPlayer player, List<OriginatedStack> out) {
-            com.darkona.adventurebackpack.playerProperties.BackpackProperty prop = com.darkona.adventurebackpack.playerProperties.BackpackProperty
+            BackpackProperty prop = BackpackProperty
                     .get(player);
             if (prop == null) return;
             ItemStack stack = prop.getWearable();
@@ -142,7 +150,7 @@ public class GraveInventorySnapshot {
     private static final class McBackpackCaptureHelper {
 
         static void capture(EntityPlayer player, List<OriginatedStack> out) {
-            de.eydamos.backpack.saves.PlayerSave save = new de.eydamos.backpack.saves.PlayerSave(player);
+            PlayerSave save = new PlayerSave(player);
             if (!save.hasPersonalBackpack()) return;
             ItemStack stack = save.getPersonalBackpack();
             if (stack != null)
@@ -163,10 +171,10 @@ public class GraveInventorySnapshot {
 
         static void capture(EntityPlayer player, List<OriginatedStack> out) {
             if (!(player instanceof EntityPlayerMP)) return;
-            micdoodle8.mods.galacticraft.core.entities.player.GCPlayerStats stats = micdoodle8.mods.galacticraft.core.entities.player.GCPlayerStats
+            GCPlayerStats stats = GCPlayerStats
                     .get((EntityPlayerMP) player);
             if (stats == null) return;
-            micdoodle8.mods.galacticraft.core.inventory.InventoryExtended inv = stats.extendedInventory;
+            InventoryExtended inv = stats.extendedInventory;
             for (int i = 0; i < inv.getSizeInventory(); i++) {
                 ItemStack stack = inv.getStackInSlot(i);
                 if (stack != null)

--- a/src/main/java/openblocks/common/GraveInventorySnapshot.java
+++ b/src/main/java/openblocks/common/GraveInventorySnapshot.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 
@@ -34,6 +35,7 @@ public class GraveInventorySnapshot {
         captureBaubles(player);
         captureAdventureBackpack(player);
         captureMcBackpack(player);
+        captureGalacticraft(player);
     }
 
     private void captureMain(EntityPlayer player) {
@@ -145,6 +147,31 @@ public class GraveInventorySnapshot {
             ItemStack stack = save.getPersonalBackpack();
             if (stack != null)
                 out.add(new OriginatedStack(new GraveSlotOrigin(GraveSlotOrigin.INV_MC_BACKPACK, 0), stack));
+        }
+    }
+
+    private void captureGalacticraft(EntityPlayer player) {
+        if (!ModPresence.GALACTICRAFT) return;
+        try {
+            GalacticraftCaptureHelper.capture(player, entries);
+        } catch (Exception e) {
+            Log.warn("GraveInventorySnapshot: failed to capture GalactiCraft slots: %s", e);
+        }
+    }
+
+    private static final class GalacticraftCaptureHelper {
+
+        static void capture(EntityPlayer player, List<OriginatedStack> out) {
+            if (!(player instanceof EntityPlayerMP)) return;
+            micdoodle8.mods.galacticraft.core.entities.player.GCPlayerStats stats = micdoodle8.mods.galacticraft.core.entities.player.GCPlayerStats
+                    .get((EntityPlayerMP) player);
+            if (stats == null) return;
+            micdoodle8.mods.galacticraft.core.inventory.InventoryExtended inv = stats.extendedInventory;
+            for (int i = 0; i < inv.getSizeInventory(); i++) {
+                ItemStack stack = inv.getStackInSlot(i);
+                if (stack != null)
+                    out.add(new OriginatedStack(new GraveSlotOrigin(GraveSlotOrigin.INV_GALACTICRAFT, i), stack));
+            }
         }
     }
 

--- a/src/main/java/openblocks/common/GraveInventorySnapshot.java
+++ b/src/main/java/openblocks/common/GraveInventorySnapshot.java
@@ -4,17 +4,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import baubles.api.BaublesApi;
-import com.darkona.adventurebackpack.playerProperties.BackpackProperty;
-import de.eydamos.backpack.saves.PlayerSave;
-import micdoodle8.mods.galacticraft.core.entities.player.GCPlayerStats;
-import micdoodle8.mods.galacticraft.core.inventory.InventoryExtended;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 
+import com.darkona.adventurebackpack.playerProperties.BackpackProperty;
+
+import baubles.api.BaublesApi;
+import de.eydamos.backpack.saves.PlayerSave;
+import micdoodle8.mods.galacticraft.core.entities.player.GCPlayerStats;
+import micdoodle8.mods.galacticraft.core.inventory.InventoryExtended;
 import openmods.Log;
 import openmods.inventory.GenericInventory;
 import tconstruct.armor.player.ArmorExtended;
@@ -129,8 +130,7 @@ public class GraveInventorySnapshot {
     private static final class AdventureBackpackCaptureHelper {
 
         static void capture(EntityPlayer player, List<OriginatedStack> out) {
-            BackpackProperty prop = BackpackProperty
-                    .get(player);
+            BackpackProperty prop = BackpackProperty.get(player);
             if (prop == null) return;
             ItemStack stack = prop.getWearable();
             if (stack != null)
@@ -171,8 +171,7 @@ public class GraveInventorySnapshot {
 
         static void capture(EntityPlayer player, List<OriginatedStack> out) {
             if (!(player instanceof EntityPlayerMP)) return;
-            GCPlayerStats stats = GCPlayerStats
-                    .get((EntityPlayerMP) player);
+            GCPlayerStats stats = GCPlayerStats.get((EntityPlayerMP) player);
             if (stats == null) return;
             InventoryExtended inv = stats.extendedInventory;
             for (int i = 0; i < inv.getSizeInventory(); i++) {

--- a/src/main/java/openblocks/common/GraveSlotOrigin.java
+++ b/src/main/java/openblocks/common/GraveSlotOrigin.java
@@ -10,6 +10,7 @@ public class GraveSlotOrigin {
     public static final String INV_BAUBLES = "baubles";
     public static final String INV_ADVENTURE_BACKPACK = "adventurebackpack";
     public static final String INV_MC_BACKPACK = "mcbackpack";
+    public static final String INV_GALACTICRAFT = "galacticraft";
 
     public final String inventoryType;
     public final int slot;

--- a/src/main/java/openblocks/common/ModPresence.java
+++ b/src/main/java/openblocks/common/ModPresence.java
@@ -10,4 +10,5 @@ public final class ModPresence {
     public static final boolean TCONSTRUCT = Loader.isModLoaded("TConstruct");
     public static final boolean ADVENTURE_BACKPACK = Loader.isModLoaded("adventurebackpack");
     public static final boolean MC_BACKPACK = Loader.isModLoaded("Backpack");
+    public static final boolean GALACTICRAFT = Loader.isModLoaded("GalacticraftCore");
 }


### PR DESCRIPTION
When retrieving items from a grave, GalactiCraft gear (oxygen mask, oxygen gear, tanks, parachute, frequency module, thermal padding) now gets placed into the correct GC extended inventory slots instead of falling into the main inventory. Baubles and vanilla armor already worked; this fills the gap for GC.

Also bumps soft dependency versions and reorganises dependencies.gradle so all compileOnly entries are grouped before devOnlyNonPublishable.