### PR TITLE
Fix hang-glider falldamage

### DIFF
--- a/src/main/java/openblocks/common/item/ItemHangGlider.java
+++ b/src/main/java/openblocks/common/item/ItemHangGlider.java
@@ -96,10 +96,22 @@ public class ItemHangGlider extends Item {
 
     @Override
     public ItemStack onItemRightClick(ItemStack itemStack, World world, EntityPlayer player) {
-        if (!world.isRemote && player != null) {
-            EntityHangGlider glider = EntityHangGlider.getEntityHangGlider(player);
-            if (glider != null) glider.setDead();
-            else spawnGlider(player);
+        if (!world.isRemote) {
+            // ensures only the serverside glider instance is created or destroyed
+            EntityHangGlider glider = null;
+            for (Object o : player.worldObj.loadedEntityList) {
+                if (o instanceof EntityHangGlider g) {
+                    if (g.getPlayer() == player && !g.isDead) {
+                        glider = g;
+                        break;
+                    }
+                }
+            }
+            if (glider != null) {
+                glider.setDead();
+                return itemStack;
+            }
+            spawnGlider(player);
         }
         return itemStack;
     }


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25168

Removes 1 simple line to re-enable fall damage from unequipping glider while flying but having glider in said hand