### PR TITLE
Cache enum `.values()`

### DIFF
--- a/src/main/java/openblocks/Config.java
+++ b/src/main/java/openblocks/Config.java
@@ -1273,7 +1273,7 @@ public class Config {
 
         if (OpenBlocks.Items.stencil != null) {
             if (stencilLoot) {
-                for (Stencil stencil : Stencil.values()) {
+                for (Stencil stencil : Stencil.VALUES) {
                     WeightedRandomChestContent drop = new WeightedRandomChestContent(
                             new ItemStack(OpenBlocks.Items.stencil, 1, stencil.ordinal()),
                             1,

--- a/src/main/java/openblocks/client/gui/GuiDrawingTable.java
+++ b/src/main/java/openblocks/client/gui/GuiDrawingTable.java
@@ -70,7 +70,7 @@ public class GuiDrawingTable extends BaseGuiContainer<ContainerDrawingTable> {
         (iconDisplay = new GuiComponentSprite(
                 80,
                 34,
-                Stencil.values()[0].getBlockIcon(),
+                Stencil.VALUES[0].getBlockIcon(),
                 TextureMap.locationBlocksTexture)).setColor(0f, 0f, 0f).setOverlayMode(true)
                         .setEnabled(inventorySlots.getSlot(0).getStack() != null);
         root.addComponent(iconDisplay);

--- a/src/main/java/openblocks/common/block/BlockCanvas.java
+++ b/src/main/java/openblocks/common/block/BlockCanvas.java
@@ -47,7 +47,7 @@ public class BlockCanvas extends OpenBlock implements IPaintableBlock {
         super.registerBlockIcons(registry);
         baseIcon = registry.registerIcon("openblocks:canvas");
         wallpaper = registry.registerIcon("openblocks:wallpaper");
-        for (Stencil stencil : Stencil.values()) stencil.registerBlockIcons(registry);
+        for (Stencil stencil : Stencil.VALUES) stencil.registerBlockIcons(registry);
     }
 
     public void setLayerForRender(int layer) {

--- a/src/main/java/openblocks/common/item/ItemStencil.java
+++ b/src/main/java/openblocks/common/item/ItemStencil.java
@@ -35,13 +35,13 @@ public class ItemStencil extends Item {
 
     @Override
     public IIcon getIconFromDamage(int dmg) {
-        return Objects.firstNonNull(Stencil.values()[dmg].getCoverBlockIcon(), itemIcon);
+        return Objects.firstNonNull(Stencil.VALUES[dmg].getCoverBlockIcon(), itemIcon);
     }
 
     @Override
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void getSubItems(Item item, CreativeTabs par2CreativeTabs, List list) {
-        for (Stencil stencil : Stencil.values()) {
+        for (Stencil stencil : Stencil.VALUES) {
             list.add(new ItemStack(item, 1, stencil.ordinal()));
         }
     }

--- a/src/main/java/openblocks/common/sync/SyncableBlockLayers.java
+++ b/src/main/java/openblocks/common/sync/SyncableBlockLayers.java
@@ -80,7 +80,7 @@ public class SyncableBlockLayers extends SyncableObjectBase {
                 layer.setRotation(stream.readByte());
                 byte b = stream.readByte();
                 if (b > -1) {
-                    layer.setStencil(Stencil.values()[b]);
+                    layer.setStencil(Stencil.VALUES[b]);
                 }
                 layer.setHasStencilCover(stream.readBoolean());
             } catch (Exception e) {


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
caching enum values() calls that got called more than 500 times during my little playtest.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge